### PR TITLE
Fix Issue 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.minecraftforge.gradle' version '5.1.+'
 }
 
-version = '1.19.4-0.0.0.1'
+version = '1.19.4-0.0.0.2'
 group = 'com.hwrd22.hwrd22expertmode' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'hwrd22expertmode'
 

--- a/src/main/java/com/hwrd22/hwrd22expertmode/event/ModEvents.java
+++ b/src/main/java/com/hwrd22/hwrd22expertmode/event/ModEvents.java
@@ -1283,7 +1283,7 @@ public class ModEvents {
                         dragon.playSound(SoundEvents.ENDER_DRAGON_SHOOT, 1.0F, 1.0F / (dragon.getRandom().nextFloat() * 0.4F + 0.8F));
                         dragon.level.addFreshEntity(fireball);
                     }
-                    if (dragon.tickCount % 200 == 0 && noCrystals) {
+                    if (dragon.tickCount % 200 == 0 && noCrystals) {  // Shulker bullet on player
                         ShulkerBullet bullet = new ShulkerBullet(dragon.level, dragon, randomPlayer, Direction.Axis.Y);
                         bullet.setPos(randomPlayer.getX(), randomPlayer.getY() + 10, randomPlayer.getZ());
                         bullet.setDeltaMovement(0.0, -2.5, 0.0);
@@ -1295,7 +1295,7 @@ public class ModEvents {
                         Random randDirection = new Random();
                         DragonFireball fireball = new DragonFireball(dragon.level, dragon, 0, 0, 0);
                         fireball.setPos(dragon.getX() + vec3.x * 16.0D, dragon.getEyeY(), fireball.getZ() + vec3.z * 16.0D);
-                        fireball.setDeltaMovement(randDirection.nextDouble(-1.0, 1.0), randDirection.nextDouble(-5, -1), randDirection.nextDouble(-1.0, 1.0));
+                        fireball.setDeltaMovement(randDirection.nextDouble(-1.0, 1.0), randDirection.nextDouble(-10, -5), randDirection.nextDouble(-1.0, 1.0));
                         dragon.playSound(SoundEvents.ENDER_DRAGON_SHOOT, 1.0F, 1.0F / (dragon.getRandom().nextFloat() * 0.4F + 0.8F));
                         dragon.level.addFreshEntity(fireball);
                     }


### PR DESCRIPTION
Modified the Dragon Fireball spawns in the Ender Dragon's Phase 2 fight to consistently prevent the Dragon Fireballs from stopping before hitting something. Results in faster rapid Dragon Fireballs, but no more Dragon Fireballs hovering in the air, fixing Issue #1 